### PR TITLE
Merge changes from the TTCC fork of TootTallyLeaderboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Version.h
 Version.cpp
 *.sln
 .vs*
+.DS_Store

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -66,12 +66,14 @@ namespace TootTallyLeaderboard
                 ShowCoolS = Config.Bind("General", "Show Cool S", false, "Show special graphic when getting SS and SSS on a song."),
                 SubmitScores = Config.Bind("General", "Suibmit Scores", true, "Submit your scores to the Toottally leaderboard."),
                 SessionDate = Config.Bind("General", "Session Date", DateTime.Now.ToString(), "The last time that the session started recording."),
-                SessionStartTT = Config.Bind("General", "TT Session Start", 0f, "The amount of TT you started the session with.")
+                SessionStartTT = Config.Bind("General", "TT Session Start", 0f, "The amount of TT you started the session with."),
+                ShowcaseMode = Config.Bind("General", "Replay Showcase Mode", false, "Hides the replay HUD and mouse cursor when viewing a replay.")
             };
 
             TootTallySettings.Plugin.MainTootTallySettingPage.AddToggle("Show Leaderboard", option.ShowLeaderboard);
             TootTallySettings.Plugin.MainTootTallySettingPage.AddToggle("Show Cool S", option.ShowCoolS);
             TootTallySettings.Plugin.MainTootTallySettingPage.AddToggle("Submit Scores", option.SubmitScores);
+            TootTallySettings.Plugin.MainTootTallySettingPage.AddToggle("Replay Showcase Mode", option.ShowcaseMode);
             AssetManager.LoadAssets(Path.Combine(Path.GetDirectoryName(Instance.Info.Location), "Assets"));
 
             ShouldUpdateSession = DateTime.Parse(Instance.option.SessionDate.Value).Date.CompareTo(DateTime.Now.Date) < 0;
@@ -96,6 +98,7 @@ namespace TootTallyLeaderboard
             public ConfigEntry<bool> SubmitScores { get; set; }
             public ConfigEntry<string> SessionDate { get; set; }
             public ConfigEntry<float> SessionStartTT { get; set; }
+            public ConfigEntry<bool> ShowcaseMode { get; set; }
         }
     }
 }

--- a/Replays/NewReplaySystem.cs
+++ b/Replays/NewReplaySystem.cs
@@ -332,7 +332,10 @@ namespace TootTallyLeaderboard.Replays
 
         public void PlaybackReplay(GameController __instance, float time)
         {
-            Cursor.visible = true;
+            if (Plugin.Instance.option.ShowcaseMode.Value)
+                Cursor.visible = false;
+            else
+                Cursor.visible = true;
             __instance.previous_high_score_surpassed = true; // prevents the new high score yellow highlight from appearing
             if (!__instance.controllermode) __instance.controllermode = true; //Still required to not make the mouse position update
 

--- a/Replays/NewReplaySystem.cs
+++ b/Replays/NewReplaySystem.cs
@@ -35,9 +35,9 @@ namespace TootTallyLeaderboard.Replays
 
         private bool _wasTouchScreenUsed;
         private bool _wasTabletUsed;
-        private bool _isTooting;
         private int _maxCombo;
         private bool _isLastNote;
+        public bool _isTooting;
         public Vector3 _mousePos;
         public bool GetIsTooting { get => _isTooting; }
 

--- a/Replays/NewReplaySystem.cs
+++ b/Replays/NewReplaySystem.cs
@@ -319,6 +319,7 @@ namespace TootTallyLeaderboard.Replays
         public void PlaybackReplay(GameController __instance, float time)
         {
             Cursor.visible = true;
+            __instance.previous_high_score_surpassed = true; // prevents the new high score yellow highlight from appearing
             if (!__instance.controllermode) __instance.controllermode = true; //Still required to not make the mouse position update
 
             if (GetIsOldReplay)

--- a/Replays/NewReplaySystem.cs
+++ b/Replays/NewReplaySystem.cs
@@ -13,6 +13,7 @@ using TootTallyCore.Utils.TootTallyGlobals;
 using TootTallyCore.Utils.TootTallyNotifs;
 using TootTallyGameModifiers;
 using TrombLoader.CustomTracks;
+using TrombLoader.Data;
 using UnityEngine;
 
 namespace TootTallyLeaderboard.Replays
@@ -45,6 +46,7 @@ namespace TootTallyLeaderboard.Replays
         public bool IsTripleS { get => GlobalVariables.gameplay_notescores[0] == 0 && GlobalVariables.gameplay_notescores[1] == 0 && GlobalVariables.gameplay_notescores[2] == 0 && GlobalVariables.gameplay_notescores[3] == 0; }
 
         public bool GetIsOldReplay => TootTallyGlobalVariables.isOldReplay;
+        public BackgroundPuppetController _backgroundPuppetController;
 
         public NewReplaySystem()
         {
@@ -347,6 +349,9 @@ namespace TootTallyLeaderboard.Replays
 
                 SetCursorPosition(__instance, newCursorPosition);
                 __instance.puppet_humanc.doPuppetControl(-newCursorPosition / 225); //225 is half of the Gameplay area:450
+                if (_backgroundPuppetController) {
+                    _backgroundPuppetController.DoPuppetControl(-newCursorPosition / 225, __instance.vibratoamt);
+                }
             }
             else
                 SetCursorPosition(__instance, (float)_currentFrame[(int)FDStruct.P]);

--- a/Replays/ReplaySystemManager.cs
+++ b/Replays/ReplaySystemManager.cs
@@ -60,6 +60,7 @@ namespace TootTallyLeaderboard.Replays
 
         private static GameObject _bg;
         private static TromboneEventManager[] _eventManagers;
+        private static bool _currentInputState = false;
 
         private static GameObject _tootTallyScorePanel;
         private static LoadingIcon _loadingSwirly;
@@ -512,7 +513,28 @@ namespace TootTallyLeaderboard.Replays
                 Traverse.Create(__instance).Field("mousePosition").SetValue(_replay._mousePos);
                 __instance.MousePositionUpdated.Invoke(new Vector3(_replay._mousePos.x / (float)_replay.ScreenWidth, _replay._mousePos.y / (float)_replay.ScreenHeight, 0f));
             }
-            
+        }
+
+        [HarmonyPatch(typeof(TromboneEventInvoker), nameof(TromboneEventInvoker.LateUpdate))]
+        [HarmonyPostfix]
+        public static void TromboneEventInvokerPostfix(TromboneEventInvoker __instance)
+        {
+            if (_replay._isTooting)
+            {
+                if (_currentInputState == false)
+                {
+                    _currentInputState = true;
+                    foreach (var manager in _eventManagers) manager.PlayerTootInputStart?.Invoke();
+                }
+            }
+            else
+            {
+                if (_currentInputState == true)
+                {
+                    _currentInputState = false;
+                    foreach (var manager in _eventManagers) manager.PlayerTootInputEnd?.Invoke();
+                }
+            }
         }
 
         #endregion

--- a/Replays/ReplaySystemManager.cs
+++ b/Replays/ReplaySystemManager.cs
@@ -16,6 +16,7 @@ using TootTallyCore.Utils.TootTallyNotifs;
 using TootTallyGameModifiers;
 using TootTallyLeaderboard.Compatibility;
 using TrombLoader.CustomTracks;
+using TrombLoader.Data;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.Localization.Components;
@@ -95,6 +96,9 @@ namespace TootTallyLeaderboard.Replays
 
             _pausePointerAnimation = new SecondDegreeDynamicsAnimation(2.5f, 1f, 0.85f);
 
+            GameObject _bg = __instance.bgcontroller.fullbgobject;
+            if (_bg) 
+                _replay._backgroundPuppetController = _bg.GetComponent<BackgroundPuppetController>();
         }
 
         [HarmonyPatch(typeof(GameController), nameof(GameController.buildNotes))]

--- a/Replays/ReplaySystemManager.cs
+++ b/Replays/ReplaySystemManager.cs
@@ -96,7 +96,8 @@ namespace TootTallyLeaderboard.Replays
             else
             {
                 OnReplayingStart();
-                SetReplayUI(__instance);
+                if (!Plugin.Instance.option.ShowcaseMode.Value)
+                    SetReplayUI(__instance);
             }
 
             _pausePointerAnimation = new SecondDegreeDynamicsAnimation(2.5f, 1f, 0.85f);

--- a/Replays/ReplaySystemManager.cs
+++ b/Replays/ReplaySystemManager.cs
@@ -58,7 +58,7 @@ namespace TootTallyLeaderboard.Replays
         private static GameObject _pauseArrow;
         private static Vector2 _pauseArrowDestination;
 
-        private static GameObject _bg;
+        private static GameObject _bgGameObject;
         private static TromboneEventManager[] _eventManagers;
         private static bool _currentInputState = false;
 
@@ -102,10 +102,10 @@ namespace TootTallyLeaderboard.Replays
 
             _pausePointerAnimation = new SecondDegreeDynamicsAnimation(2.5f, 1f, 0.85f);
 
-            _bg = __instance.bgcontroller.fullbgobject;
-            if (_bg) 
-                _replay._backgroundPuppetController = _bg.GetComponent<BackgroundPuppetController>();
-                _eventManagers = _bg.GetComponentsInChildren<TromboneEventManager>();
+            _bgGameObject = __instance.bgcontroller.fullbgobject;
+            if (_bgGameObject)
+                _replay._backgroundPuppetController = _bgGameObject.GetComponent<BackgroundPuppetController>();
+            _eventManagers = _bgGameObject.GetComponentsInChildren<TromboneEventManager>();
         }
 
         [HarmonyPatch(typeof(GameController), nameof(GameController.buildNotes))]
@@ -240,10 +240,10 @@ namespace TootTallyLeaderboard.Replays
                 GameObject prevHighLabel = GameObject.Find("Canvas/FullPanel/LeftLabels/PREV. HI SCORE");
                 Text[] prevHighLabelText = prevHighLabel.GetComponentsInChildren<Text>();
                 foreach (Text text in prevHighLabelText)
-                {
                     text.text = "Player"; // TODO: this should probably be localised at some point in the future
-                }
-            } else {
+            }
+            else
+            {
                 GameObject lowerRightPanel = __instance.yellowwave.transform.parent.gameObject;
 
                 GameObject UICanvas = lowerRightPanel.transform.parent.gameObject;
@@ -416,12 +416,12 @@ namespace TootTallyLeaderboard.Replays
         [HarmonyPostfix]
         static void PauseCanvasAddWarning(PauseCanvasController __instance)
         {
-            _toottallyPauseWarning = GameObject.Instantiate(__instance.control_hint_box, __instance.panelobj.transform.parent);            
+            _toottallyPauseWarning = GameObject.Instantiate(__instance.control_hint_box, __instance.panelobj.transform.parent);
             _toottallyPauseWarning.transform.localScale = new Vector3(0, 0, 1);
             var rect = _toottallyPauseWarning.GetComponent<RectTransform>();
             rect.anchoredPosition = Vector2.zero;
             rect.sizeDelta = new Vector2(210, 46);
-            rect.anchorMin = rect.anchorMax =  new Vector2(.5f, .18f);
+            rect.anchorMin = rect.anchorMax = new Vector2(.5f, .18f);
             rect.pivot = new Vector2(.5f, .5f);
             _toottallyPauseWarning.GetComponent<Image>().color = new Color(.1f, .1f, 0, .5f);
             var border = _toottallyPauseWarning.transform.GetChild(0).gameObject;
@@ -430,7 +430,7 @@ namespace TootTallyLeaderboard.Replays
             GameObjectFactory.DestroyFromParent(border, "Image (2)");
             GameObjectFactory.DestroyFromParent(border, "Image (3)");
             GameObjectFactory.DestroyFromParent(border, "txt-track-vol");
-            
+
             var text = border.transform.Find("txt-quick-restart").GetComponent<Text>();
             if (text.TryGetComponent(out LocalizeStringEvent locEvent))
                 GameObject.DestroyImmediate(locEvent);

--- a/Replays/ReplaySystemManager.cs
+++ b/Replays/ReplaySystemManager.cs
@@ -222,24 +222,36 @@ namespace TootTallyLeaderboard.Replays
             if (!modifiers.ToLower().Contains("none"))
                 __instance.txt_trackname.text += $" [{modifiers}]";
 
-            GameObject lowerRightPanel = __instance.yellowwave.transform.parent.gameObject;
+            if (wasPlayingReplay)
+            {
+                __instance.prevhigh = GlobalVariables.gameplay_scoretotal; // prevents the new high score text from showing
+                __instance.txt_prevhigh.text = _replay.GetUsername;
+                GameObject prevHighLabel = GameObject.Find("Canvas/FullPanel/LeftLabels/PREV. HI SCORE");
+                Text[] prevHighLabelText = prevHighLabel.GetComponentsInChildren<Text>();
+                foreach (Text text in prevHighLabelText)
+                {
+                    text.text = "Player"; // TODO: this should probably be localised at some point in the future
+                }
+            } else {
+                GameObject lowerRightPanel = __instance.yellowwave.transform.parent.gameObject;
 
-            GameObject UICanvas = lowerRightPanel.transform.parent.gameObject;
+                GameObject UICanvas = lowerRightPanel.transform.parent.gameObject;
 
-            GameObject ttHitbox = LeaderboardFactory.CreateDefaultPanel(UICanvas.transform, new Vector2(365, -23), new Vector2(56, 112), "ScorePanelHitbox");
-            GameObjectFactory.CreateSingleText(ttHitbox.transform, "ScorePanelHitboxText", "<", GameObjectFactory.TextFont.Multicolore);
+                GameObject ttHitbox = LeaderboardFactory.CreateDefaultPanel(UICanvas.transform, new Vector2(365, -23), new Vector2(56, 112), "ScorePanelHitbox");
+                GameObjectFactory.CreateSingleText(ttHitbox.transform, "ScorePanelHitboxText", "<", GameObjectFactory.TextFont.Multicolore);
 
-            GameObject panelBody = LeaderboardFactory.CreateDefaultPanel(UICanvas.transform, new Vector2(750, 0), new Vector2(600, 780), "TootTallyScorePanel");
-            _tootTallyScorePanel = panelBody.transform.Find("scoresbody").gameObject;
-            VerticalLayoutGroup vertLayout = _tootTallyScorePanel.AddComponent<VerticalLayoutGroup>();
-            vertLayout.padding = new RectOffset(2, 2, 2, 2);
-            vertLayout.childAlignment = TextAnchor.MiddleCenter;
-            vertLayout.childForceExpandHeight = vertLayout.childForceExpandWidth = true;
-            _loadingSwirly = GameObjectFactory.CreateLoadingIcon(panelBody.transform, Vector2.zero, new Vector2(128, 128), AssetManager.GetSprite("icon.png"), true, "LoadingSwirly");
-            _loadingSwirly.Show();
-            _loadingSwirly.StartRecursiveAnimation();
+                GameObject panelBody = LeaderboardFactory.CreateDefaultPanel(UICanvas.transform, new Vector2(750, 0), new Vector2(600, 780), "TootTallyScorePanel");
+                _tootTallyScorePanel = panelBody.transform.Find("scoresbody").gameObject;
+                VerticalLayoutGroup vertLayout = _tootTallyScorePanel.AddComponent<VerticalLayoutGroup>();
+                vertLayout.padding = new RectOffset(2, 2, 2, 2);
+                vertLayout.childAlignment = TextAnchor.MiddleCenter;
+                vertLayout.childForceExpandHeight = vertLayout.childForceExpandWidth = true;
+                _loadingSwirly = GameObjectFactory.CreateLoadingIcon(panelBody.transform, Vector2.zero, new Vector2(128, 128), AssetManager.GetSprite("icon.png"), true, "LoadingSwirly");
+                _loadingSwirly.Show();
+                _loadingSwirly.StartRecursiveAnimation();
 
-            new SlideTooltip(ttHitbox, panelBody, new Vector2(750, 0), new Vector2(225, 0));
+                new SlideTooltip(ttHitbox, panelBody, new Vector2(750, 0), new Vector2(225, 0));
+            }
 
         }
 

--- a/TootTallyLeaderboard.csproj
+++ b/TootTallyLeaderboard.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net48</TargetFramework>
 		<AssemblyName>TootTallyLeaderboard</AssemblyName>
 		<Description>TootTally Leaderboard and Replay module</Description>
-		<Version>1.1.1</Version>
+		<Version>1.1.2</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>latest</LangVersion>
 		<TromboneChampDir>E:\SteamLibrary\steamapps\common\TromboneChamp</TromboneChampDir>


### PR DESCRIPTION
This PR contains most of the changes I made to TootTallyLeaderboard replay viewer for TTCC, excluding the offline replay viewer.

- Prevent the in-game score from turning yellow (when a new high score is reached)
- Replaced the previous high score on the points screen with the name of the player from the replay and hid the TootTally Score Panel on the right. Also prevented the "New High Score" text from appearing
![image](https://github.com/TootTally/TootTallyLeaderboard/assets/15108194/f64aff28-9993-400f-b642-dc709a463493)
- Fix background tromboners not animating correctly
- Send mouse and toot input events to backgrounds (doesn't work for old replays that have no mouse position data)
- Add a Replay Showcase Mode to the TootTally settings menu, which hides the replay UI and mouse cursor

All these changes only affect replays, normal gameplay should be the same.